### PR TITLE
Avoid the shortcut to be named 'do'

### DIFF
--- a/src/NamingStrategy.php
+++ b/src/NamingStrategy.php
@@ -11,7 +11,7 @@ class NamingStrategy
         {
             for ($i = 1; $i <= strlen($model->slug); $i++) {
                 $nameCandidate = substr($model->slug, 0, $i);
-                if(!$modelCollection->hasSeveralLike($nameCandidate)  && !function_exists($nameCandidate) && $nameCandidate != "names" && $nameCandidate != "re") {
+                if(!$modelCollection->hasSeveralLike($nameCandidate)  && !function_exists($nameCandidate) && $nameCandidate != "names" && $nameCandidate != "re" && $nameCandidate != "do") {
                     $names[$model->classWithFullNamespace] = $nameCandidate;
                     break;
                 }


### PR DESCRIPTION
I has a model call Document that creates a "do" shortcut i think is a reserved word that thrown this error:

`local.ERROR: Parse error: syntax error, unexpected 'do' (T_DO), expecting '(' {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Parse error: syntax error, unexpected 'do' (T_DO), expecting '(' at ..../storage/TinxIncludes.php:114)`

