### PR TITLE
Ignore Abstract Models

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -27,10 +27,13 @@ class Model
                     if ($result === '.' or $result === '..') continue;
                     $filename = $fullBasePath . '/' . $result;
                     if (is_dir($filename)) {
-                        // This requires only model files to be present in subfolders, anything else will brake it.
+                        // This requires only model files to be present in subfolders, anything else will break it.
                         //$models = array_merge($models, $this->models($filename));
                     }else{
                         $class = $namespace . '\\' . substr($result,0,-4);
+                        if ((new \ReflectionClass($class))->isAbstract()) {
+                            continue;
+                        }
                         $models->push(new Model($class));
 
                     }


### PR DESCRIPTION
Abstract models currently throw fatal errors (see #10).

Using [reflection](https://secure.php.net/manual/en/reflectionclass.isabstract.php), this PR checks if a scanned model is abstract and if so, ignores it.

🤓👍