### PR TITLE
Last Model Instance Variables (e.g. "$u_")

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,18 @@ This will allow you to immediatly test out your changes.
 
 Tinx sniffs your models and prepare the following shortcuts.
 
-| Example usage        | Equals           |
-| ------------- |:-------------:|
-| ```$u```      | ```App\User::first()``` |
-| ```$c```      | ```App\Models\Car::first()``` |
-| ```u(3)```      | ```App\User::find(3)``` |
-| ```u("gmail")```      | ```Where "gmail" is found in any column.``` |
-| ```u()```      | ```"App\User"``` |
-| ```u()::where(...)```      | ```App\User::where(...)``` |
+| Example Usage     | Equals                                    |
+|:----------------- |:----------------------------------------- |
+| `$u`              | `App\User::first()`                       |
+| `$u_`             | `App\User::latest()->first()`             |
+| `$c`              | `App\Models\Car::first()`                 |
+| `u(3)`            | `App\User::find(3)`                       |
+| `u("gmail")`      | `Where "gmail" is found in any column.`   |
+| `u()`             | `"App\User"`                              |
+| `u()::where(...)` | `App\User::where(...)`                    |
 
 The naming conventions are decided by a strategy function, for instance "shortestUnique".
-Lets say you have two models ```Car``` and ```Crocodile```. Tinx will then prepare the following variables and functions: ```$ca```, ```ca()```, ```$cr```, ```cr()```.
+Lets say you have two models `Car` and `Crocodile`. Tinx will then prepare the following variables and functions: `$ca`, `$ca_`, `ca()`, `$cr`, `$cr_`, `cr()`.
 
 ## Contributing
 Please post issues and send PR:s.

--- a/src/IncludeManager.php
+++ b/src/IncludeManager.php
@@ -16,15 +16,18 @@ class IncludeManager
     {
         $template = file_get_contents(__DIR__ . "/Stubs/TinxIncludes.php");
         $FIRST_MODEL_INSTANCE_VARIABLES = "";
+        $LAST_MODEL_INSTANCE_VARIABLES = "";
         $MODEL_FUNCTIONS = "";
         foreach($names as $class => $name)
         {
             $FIRST_MODEL_INSTANCE_VARIABLES .= '$' . $name . ' = ' . $class . "::first();" . "\n";
+            $LAST_MODEL_INSTANCE_VARIABLES .= '$' . $name . '_ = ' . $class . "::latest()->first();" . "\n";
             $MODEL_FUNCTIONS                .= 'function ' . $name . '($input = null) { return getQueryInstance("'. $class .'", $input);}' . "\n";
         }
 
         $replacementPairs = [
             '$FIRST_MODEL_INSTANCE_VARIABLES$' => $FIRST_MODEL_INSTANCE_VARIABLES,
+            '$LAST_MODEL_INSTANCE_VARIABLES$' => $LAST_MODEL_INSTANCE_VARIABLES,
             '$MODEL_FUNCTIONS$' => $MODEL_FUNCTIONS,
             '$TINX_NAMES$' => '$names = ' . var_export($names, true) . ';'
         ];

--- a/src/Stubs/TinxIncludes.php
+++ b/src/Stubs/TinxIncludes.php
@@ -55,5 +55,8 @@ function getQueryInstance($class, $input)
 // Insert "first" variables, $u etc
 $FIRST_MODEL_INSTANCE_VARIABLES$
 
+// Insert "last" variables, $u_ etc
+$LAST_MODEL_INSTANCE_VARIABLES$
+
 // Insert model functions
 $MODEL_FUNCTIONS$


### PR DESCRIPTION
Tinx currently creates first model instance variables (e.g. "$u").

This PR enables the creation of last model instance variables (e.g. "$u_").

Last models are retrieved via [`[model]->latest()->first()`](https://github.com/laravel/framework/blob/ac7eee2a13beb53b4806d1fb830f49dbf40df30c/src/Illuminate/Database/Query/Builder.php#L1430) (i.e. created_at desc).

🤓👍