### PR TITLE
Storage Disk

### DIFF
--- a/src/Commands/TinxCommand.php
+++ b/src/Commands/TinxCommand.php
@@ -49,7 +49,7 @@ class TinxCommand extends Command
 
             Artisan::call('tinker', [
                 'include' => [
-                    'storage/TinxIncludes.php'
+                    resolve('tinx.storage')->path('includes.php')
                 ]
             ]);
 

--- a/src/IncludeManager.php
+++ b/src/IncludeManager.php
@@ -29,9 +29,7 @@ class IncludeManager
             '$TINX_NAMES$' => '$names = ' . var_export($names, true) . ';'
         ];
         $filledTemplate = IncludeManager::fill_template($replacementPairs, $template);
-        $file = fopen("storage/TinxIncludes.php", "w") or die("Unable to open tinx include file!");
-        fwrite($file, $filledTemplate);
-        fclose($file);
+        resolve('tinx.storage')->put('includes.php', $filledTemplate);
         return true;
     }
 

--- a/src/State.php
+++ b/src/State.php
@@ -21,17 +21,12 @@ class State
 
     public static function setStateFileMessage($message)
     {
-        $file = fopen("storage/tinx.state", "w") or die("Unable to open tinx state file!");
-        fwrite($file, $message);
-        fclose($file);
+        resolve('tinx.storage')->put('state', $message);
         return $message;
     }
 
     public static function getStateFileMessage()
     {
-        $file = fopen("storage/tinx.state", "r") or die("Unable to open tinx state file!");
-        $message = fgets($file);
-        fclose($file);
-        return $message;
+        return resolve('tinx.storage')->get('state');
     }
 }

--- a/src/TinxServiceProvider.php
+++ b/src/TinxServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Ajthinking\Tinx;
 
-
 use Illuminate\Support\ServiceProvider;
 use Ajthinking\Tinx\Commands\TinxCommand;
 
@@ -22,6 +21,8 @@ class TinxServiceProvider extends ServiceProvider
         $this->commands([
             TinxCommand::class
         ]);
+
+        $this->ignoreStorageFiles();
     }
 
     /**
@@ -32,5 +33,32 @@ class TinxServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/tinx.php', 'tinx');
+
+        $this->configureStorageDisk();
+    }
+
+    /**
+     * @return void
+     * */
+    private function configureStorageDisk()
+    {
+        config([
+            'filesystems.disks.tinx' => config('tinx.storage.disk', [
+                'driver' => 'local',
+                'root' => storage_path('tinx'),
+            ]),
+        ]);
+
+        $this->app->singleton('tinx.storage', function ($app) {
+            return $app['filesystem']->disk('tinx');
+        });
+    }
+
+    /**
+     * @return void
+     * */
+    private function ignoreStorageFiles()
+    {
+        resolve('tinx.storage')->put('.gitignore', '*'.PHP_EOL.'!.gitignore');
     }
 }

--- a/src/TinxServiceProvider.php
+++ b/src/TinxServiceProvider.php
@@ -43,7 +43,7 @@ class TinxServiceProvider extends ServiceProvider
     private function configureStorageDisk()
     {
         config([
-            'filesystems.disks.tinx' => config('tinx.storage.disk', [
+            'filesystems.disks.tinx' => config('filesystems.disks.tinx', [
                 'driver' => 'local',
                 'root' => storage_path('tinx'),
             ]),


### PR DESCRIPTION
Tinx currently stores files in your project's `/storage` directory via PHP functions.

This PR replaces those PHP functions with calls to a new Laravel disk "tinx", which by default, stores files in `/storage/tinx`.

If required, the default "tinx" disk configuration can be completely overwritten by adding your own "tinx" disk settings to your project's `/config/filesystems.php` file, like so… 

```php
<?php

// 'config/filesystems.php'

return [

    // etc…

    'disks' => [

        // etc…

        'tinx' => [
            'driver' => 'local',
            'root' => storage_path('custom/tinx/storage/path'),
        ],

    ],

];
```

This PR also adds an appropriate `.gitignore` file to the root of your "tinx" disk, ensuring Tinx generated files are hidden from source control.

🤓👍