### PR TITLE
excludes hidden files from directory scan

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -4,11 +4,12 @@ namespace Ajthinking\Tinx;
 
 class Model
 {
-    public function __construct($classWithFullNamespace) {
+    public function __construct($classWithFullNamespace)
+    {
         $this->classWithFullNamespace = $classWithFullNamespace;
-        $parts = explode('\\',$classWithFullNamespace);
-        $this->className = end($parts);
-        $this->slug = str_slug($this->className);
+        $parts                        = explode('\\', $classWithFullNamespace);
+        $this->className              = end($parts);
+        $this->slug                   = str_slug($this->className);
     }
 
     public static function all()
@@ -17,20 +18,17 @@ class Model
 
         $models = collect();
 
-        foreach($namespacesAndPaths as $namespace => $path)
-        {
+        foreach ($namespacesAndPaths as $namespace => $path) {
             $fullBasePath = base_path() . $path;
-            if(file_exists($fullBasePath))
-            {
-                $results = scandir($fullBasePath);
+            if (file_exists($fullBasePath)) {
+                $results = self::nonHiddenFiles($fullBasePath);
                 foreach ($results as $result) {
-                    if ($result === '.' or $result === '..') continue;
                     $filename = $fullBasePath . '/' . $result;
                     if (is_dir($filename)) {
                         // This requires only model files to be present in subfolders, anything else will break it.
                         //$models = array_merge($models, $this->models($filename));
-                    }else{
-                        $class = $namespace . '\\' . substr($result,0,-4);
+                    } else {
+                        $class = $namespace . '\\' . substr($result, 0, -4);
                         if ((new \ReflectionClass($class))->isAbstract()) {
                             continue;
                         }
@@ -41,6 +39,15 @@ class Model
             }
         }
         return $models;
+    }
+
+    /**
+     * @param string $fullBasePath
+     * @return array
+     */
+    private static function nonHiddenFiles($fullBasePath)
+    {
+        return preg_grep('/^([^.])/', scandir($fullBasePath));
     }
 
     public function empty()
@@ -54,7 +61,8 @@ class Model
     }
 
     // attributes - hidden attributes as non associative array
-    public function publicAttributes() {
+    public function publicAttributes()
+    {
         return array_values(
             array_diff(
                 array_keys(
@@ -65,7 +73,8 @@ class Model
         );
     }
 
-    public function hasTable() {
+    public function hasTable()
+    {
         //
     }
 }


### PR DESCRIPTION
I was getting a `Class App\.DS_S does not exist` error when trying to run this command. This change simply excludes all files or directories that start with a dot. I also included a few PSR-2 styling changes for fun. 