### PR TITLE
Add Windows hidden file detection

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -49,7 +49,7 @@ class Model
      */
     private static function nonHiddenFiles($fullBasePath)
     {
-        return preg_grep('/^([^.])/', scandir($fullBasePath));
+        return preg_grep('/^([^.|^~])/', scandir($fullBasePath));
     }
 
     public function empty()


### PR DESCRIPTION
Windows uses `~` as identifier for hidden files. Adding this pattern to be excluded from scandir.