### PR TITLE
Optional "Tableless" Models

### DIFF
--- a/config/tinx.php
+++ b/config/tinx.php
@@ -10,5 +10,7 @@ return [
     'strategy' => 'shortestUnique',
 
     'latest_column' => 'created_at',
+
+    'tableless_models' => false,
     
 ];

--- a/src/IncludeManager.php
+++ b/src/IncludeManager.php
@@ -19,7 +19,8 @@ class IncludeManager
      * */
     public static function prepareIncludesFile($names)
     {
-        $contents = view()->file(__DIR__.'/resources/includes.blade.php', compact('names'))->render();
+        $config = config('tinx');
+        $contents = view()->file(__DIR__.'/resources/includes.blade.php', compact('names', 'config'))->render();
         $contentsWithPhpTag = '<?php'.PHP_EOL.PHP_EOL.$contents;
         app('tinx.storage')->put('includes.php', $contentsWithPhpTag);
     }


### PR DESCRIPTION
Continuing from the last PR on the same feature branch…

* If config "tableless_models" is set to `false` (default), models without database tables are removed from the `$names`/`names()` array (i.e. no `$u`, `$u_` or `u()`)
* If config "tableless_models" is set to `true`, models without database tables will still be instantiated (i.e. `$u` and `$u_` return a new instance) and the model helper function will return that model class path (e.g. `u()` returns `App\User`)

🤓👍