### PR TITLE
Recursive Model Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,13 @@ Once published, edit `config/tinx.php` where appropriate to suit your needs:
 return [
 
     /**
-     * The namespaces and relating base paths to search for models.
+     * Base paths to search for models (paths ending in '*' search recursively).
      * */
-    'namespaces_and_paths' => [
-        'App' => '/app',
-        'App\Models' => '/app/Models',
-        // 'Another\Namespace' => '/path/to/another/namespace/models'
+    'model_paths' => [
+        '/app',
+        '/app/Models/*',
+        // '/also/search/this/directory',
+        // '/also/search/this/directory/recursively/*',
     ],
 
     /**

--- a/config/tinx.php
+++ b/config/tinx.php
@@ -3,12 +3,13 @@
 return [
 
     /**
-     * The namespaces and relating base paths to search for models.
+     * Base paths to search for models (paths ending in '*' search recursively).
      * */
-    'namespaces_and_paths' => [
-        'App' => '/app',
-        'App\Models' => '/app/Models',
-        // 'Another\Namespace' => '/path/to/another/namespace/models'
+    'model_paths' => [
+        '/app',
+        '/app/Models/*',
+        // '/also/search/this/directory',
+        // '/also/search/this/directory/recursively/*',
     ],
 
     /**

--- a/src/Console/NamesTable.php
+++ b/src/Console/NamesTable.php
@@ -68,7 +68,7 @@ class NamesTable
     public function render(...$filters)
     {
         if (0 === count($this->names)) {
-            return $this->command->warn("No models found (see: config/tinx.php > namespaces_and_paths).");
+            return $this->command->warn("No models found (see: config/tinx.php > model_paths).");
         }
 
         $rows = $this->getRows();

--- a/src/Models/Models.php
+++ b/src/Models/Models.php
@@ -2,6 +2,7 @@
 
 namespace Ajthinking\Tinx\Models;
 
+use Exception;
 use Illuminate\Support\Collection;
 
 class Models extends Collection
@@ -12,6 +13,7 @@ class Models extends Collection
      */
     public function __construct($items = [])
     {
+        $this->filesystem = app('files');
         $this->only = $this->getOnlyArray();
         $this->except = $this->getExceptArray();
 
@@ -39,25 +41,26 @@ class Models extends Collection
      * */
     private function getModels()
     {
-        $namespacePaths = config('tinx.namespaces_and_paths', [
-            'App' => '/app',
-            'App\Models' => '/app/Models',
+        $modelFilePaths = config('tinx.model_paths', [
+            '/app',
+            '/app/Models/*',
         ]);
 
         $models = collect();
 
-        foreach ($namespacePaths as $namespace => $path) {
-            $namespacePath = base_path($path);
-            if (false === file_exists($namespacePath)) {
+        foreach ($modelFilePaths as $modelFilePath) {
+            $absoluteFilePath = $this->getAbsoluteFilePath($modelFilePath);
+            $recursive = false;
+            if (ends_with($absoluteFilePath, '*')) {
+                $absoluteFilePath = rtrim($absoluteFilePath, '/*');
+                $recursive = true;
+            }
+            if (false === file_exists($absoluteFilePath)) {
                 continue;
             }
-            foreach ($this->getVisibleFiles($namespacePath) as $file) {
-                $fullClassName = $namespace.'\\'.substr($file, 0, -4);
-                if ($this->isHidden($fullClassName)) {
-                    continue;
-                }
-                $filePath = $namespacePath.'/'.$file;
-                if (ModelValidator::for($filePath, $fullClassName)->fails()) {
+            foreach ($this->getVisibleFiles($absoluteFilePath, $recursive) as $filePath) {
+                $fullClassName = $this->getFullClassName($filePath);
+                if ($this->shouldNotInclude($filePath, $fullClassName)) {
                     continue;
                 }
                 $models->push(new Model($fullClassName));
@@ -68,20 +71,86 @@ class Models extends Collection
     }
 
     /**
-     * @param string $path
-     * @return array
-     */
-    private function getVisibleFiles($path)
+     * @param string $filePath
+     * @return string
+     * */
+    private function getAbsoluteFilePath($path)
     {
-        return preg_grep('/^([^.|^~])/', scandir($path));
+        return base_path(trim($path, '/'));
     }
 
     /**
+     * @param string $path
+     * @param bool $recursive
+     * @return array
+     */
+    private function getVisibleFiles($path, $recursive = false)
+    {
+        $method = $recursive ? 'allFiles' : 'files';
+
+        return collect($this->filesystem->$method($path))->map(function ($file) {
+            return is_string($file) ? $file : $file->getRealPath();
+        })->values();
+    }
+
+    /**
+     * @param string $path
+     * @return $string
+     * */
+    private function getFullClassName($path)
+    {
+        $matches = [];
+
+        try {
+            preg_match($this->getNamespaceRegex(), $this->filesystem->get($path), $matches);
+        } catch (Exception $e) {
+            // Fail silently…
+        }
+
+        $namespace = array_get($matches, 1);
+
+        if (null === $namespace) {
+            return null;
+        }
+
+        return $namespace.'\\'.$this->filesystem->name($path);
+    }
+
+    /**
+     * @return string
+     * */
+    private function getNamespaceRegex()
+    {
+        $start = $end = '/';
+        $wordBoundary = '\b';
+        $oneOrMoreSpaces = '\s+';
+        $oneOrMoreWordsOrSlashes = '[\w|\\\]+';
+        $zeroOrMoreSpaces = '\s*';
+        $startGroup = '(';
+        $endGroup = ')';
+        $ignoreCase = 'i';
+
+        return
+            $start.
+            $wordBoundary.'namespace'.$wordBoundary.$oneOrMoreSpaces.
+            $startGroup.$oneOrMoreWordsOrSlashes.$endGroup.
+            $zeroOrMoreSpaces.
+            ';'.
+            $end.
+            $ignoreCase;
+    }
+
+    /**
+     * @param string $filePath
      * @param string $fullClassName
      * @return bool
      * */
-    private function isHidden($fullClassName)
+    private function shouldNotInclude($filePath, $fullClassName)
     {
+        if (null === $fullClassName) {
+            return true;
+        }
+
         if ($this->except && in_array($fullClassName, $this->except)) {
             return true;
         }
@@ -90,6 +159,20 @@ class Models extends Collection
             return true;
         }
 
+        if (ModelValidator::for($filePath, $fullClassName)->fails()) {
+            return true;
+        }
+
         return false;
+    }
+
+    /**
+     * Added for Laravel 5.2 backwards compatibility.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function toBase()
+    {
+        return new Collection($this);
     }
 }

--- a/src/Naming/StrategyFactory.php
+++ b/src/Naming/StrategyFactory.php
@@ -17,7 +17,7 @@ class StrategyFactory
     {
         $strategy = config('tinx.strategy', 'pascal');
 
-        $models = new Models;
+        $models = with(new Models)->toBase();
 
         return static::make($strategy, $models);
     }


### PR DESCRIPTION
This PR implements recursive model searching by changing `namespaces_and_paths` to `model_paths` in Tinx's config…

```php
<?php

// 'config/tinx.php'

return [

    /**
     * Base paths to search for models (paths ending in '*' search recursively).
     * */
    'model_paths' => [
        '/app',
        '/app/Models/*',
        // '/also/search/this/directory',
        // '/also/search/this/directory/recursively/*',
    ],

    // etc…

];
```

…and then recursively searching paths ending in `*`.

No more declaring namespaces – just pass an array of paths and Tinx detects them for you!

To test, please ensure you've force published Tinx's config file first:

```
php artisan vendor:publish --provider=Ajthinking\\Tinx\\TinxServiceProvider --force
```

As this is a breaking change, if approved it'll probably require a full point release (i.e. `2.0.0`).

🤓👍